### PR TITLE
kwargs.getを廃止して、全て直接参照するよう修正

### DIFF
--- a/policy/conv_ddqn.py
+++ b/policy/conv_ddqn.py
@@ -12,17 +12,17 @@ torch.set_default_dtype(torch.float64)
 class ConvDDQN(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/conv_dqn.py
+++ b/policy/conv_dqn.py
@@ -12,17 +12,17 @@ torch.set_default_dtype(torch.float64)
 class ConvDQN(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/conv_dqn_atari.py
+++ b/policy/conv_dqn_atari.py
@@ -12,22 +12,22 @@ torch.set_default_dtype(torch.float64)
 class ConvDQNAtari(nn.Module):
     def __init__(self, model=ConvQAtariNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
         self.epsilon_start = 1.0
         self.epsilon_end = 0.01
         self.epsilon_decay = 1e6
         self.total_steps = 0
         self.warmup_steps = 1e2
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/conv_dqn_rnd.py
+++ b/policy/conv_dqn_rnd.py
@@ -13,17 +13,17 @@ torch.set_default_dtype(torch.float64)
 class ConvDQN_RND(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/conv_rsrs_dqn.py
+++ b/policy/conv_rsrs_dqn.py
@@ -14,20 +14,20 @@ torch.set_default_dtype(torch.float64)
 class ConvRSRSDQN(nn.Module):
     def __init__(self, model=ConvRSRSNet, **kwargs):
         super().__init__()
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 64)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -41,7 +41,7 @@ class ConvRSRSDQN(nn.Module):
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
         self.q_list = [[] for _ in range(self.state_space)]

--- a/policy/conv_rsrsaleph_dqn.py
+++ b/policy/conv_rsrsaleph_dqn.py
@@ -14,20 +14,20 @@ torch.set_default_dtype(torch.float64)
 class ConvRSRSAlephDQN(nn.Module):
     def __init__(self, model=ConvRSRSAlephNet, **kwargs):
         super().__init__()
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 64)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
@@ -14,21 +14,21 @@ torch.set_default_dtype(torch.float64)
 class ConvRSRSAlephQEpsRASChoiceDQNAtari:
     def __init__(self, model=ConvRSRSAtariNet, **kwargs):
         super().__init__()
-        self.warmup = kwargs.get('warmup', 10)
+        self.warmup = kwargs['warmup']
         self.warmup_steps = 1e3
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 64)
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -15,20 +15,20 @@ torch.set_default_dtype(torch.float64)
 class ConvRSRSAlephQEpsRASChoiceDQN_RND:
     def __init__(self, model=ConvRSRSNet, **kwargs):
         super().__init__()
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 64)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/conv_rsrsdyn_dqn.py
+++ b/policy/conv_rsrsdyn_dqn.py
@@ -14,20 +14,20 @@ torch.set_default_dtype(torch.float64)
 class ConvRSRSDynDQN(nn.Module):
     def __init__(self, model=ConvRSRSNet, **kwargs):
         super().__init__()
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 64)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
-        self.neighbor_frames = kwargs.get('neighbor_frames', 4)
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.neighbor_frames = kwargs['neighbor_frames']
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cpu')
@@ -41,7 +41,7 @@ class ConvRSRSDynDQN(nn.Module):
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
         self.q_list = [[] for _ in range(self.state_space)]

--- a/policy/ddqn.py
+++ b/policy/ddqn.py
@@ -11,15 +11,15 @@ torch.set_default_dtype(torch.float64)
 
 class DDQN:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/dqn.py
+++ b/policy/dqn.py
@@ -11,15 +11,15 @@ torch.set_default_dtype(torch.float64)
 
 class DQN:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/dqn_rnd.py
+++ b/policy/dqn_rnd.py
@@ -12,15 +12,15 @@ torch.set_default_dtype(torch.float64)
 
 class DQN_RND:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/duelingddqn.py
+++ b/policy/duelingddqn.py
@@ -11,15 +11,15 @@ torch.set_default_dtype(torch.float64)
 
 class DuelingDDQN:
     def __init__(self, model=DuelingNet, **kwargs):
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/duelingdqn.py
+++ b/policy/duelingdqn.py
@@ -11,15 +11,15 @@ torch.set_default_dtype(torch.float64)
 
 class DuelingDQN:
     def __init__(self, model=DuelingNet, **kwargs):
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model

--- a/policy/rsrs_ddqn.py
+++ b/policy/rsrs_ddqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSDDQN:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -38,7 +38,7 @@ class RSRSDDQN:
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
         self.q_list = [[] for _ in range(self.state_space)]

--- a/policy/rsrs_dqn.py
+++ b/policy/rsrs_dqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSDQN:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -38,7 +38,7 @@ class RSRSDQN:
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
         self.q_list = [[] for _ in range(self.state_space)]

--- a/policy/rsrs_duelingddqn.py
+++ b/policy/rsrs_duelingddqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSDuelingDDQN:
     def __init__(self, model=RSRSDuelingNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -38,7 +38,7 @@ class RSRSDuelingDDQN:
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
         self.q_list = [[] for _ in range(self.state_space)]

--- a/policy/rsrs_duelingdqn.py
+++ b/policy/rsrs_duelingdqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSDuelingDQN:
     def __init__(self, model=RSRSDuelingNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -38,7 +38,7 @@ class RSRSDuelingDQN:
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.gamma_G = 0.9
-        self.aleph_G = kwargs.get('aleph_G', 1.0)
+        self.aleph_G = kwargs['aleph_G']
         self.E_G = 0
         # self.zeta = 1
 

--- a/policy/rsrsaleph_dqn.py
+++ b/policy/rsrsaleph_dqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSAlephDQN:
     def __init__(self, model=RSRSAlephNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/rsrsaleph_q_eps_dqn.py
+++ b/policy/rsrsaleph_q_eps_dqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSAlephQEpsDQN:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSAlephQEpsRASChoiceDQN:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -14,18 +14,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSAlephQEpsRASChoiceDQN_RND:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/policy/rsrsaleph_q_eps_ras_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_dqn.py
@@ -13,18 +13,18 @@ torch.set_default_dtype(torch.float64)
 
 class RSRSAlephQEpsRASDQN:
     def __init__(self, model=RSRSNet, **kwargs):
-        self.warmup = kwargs.get('warmup', 10)
-        self.k = kwargs.get('k', 5)
-        self.zeta = kwargs.get('zeta', 0.008)
-        self.alpha = kwargs.get('alpha', 0.0001)
-        self.gamma = kwargs.get('gamma', 0.99)
-        self.epsilon = kwargs.get('epsilon', 0.01)
-        self.tau = kwargs.get('tau', 0.01)
-        self.hidden_size = kwargs.get('hidden_size', 128)
+        self.warmup = kwargs['warmup']
+        self.k = kwargs['k']
+        self.zeta = kwargs['zeta']
+        self.alpha = kwargs['alpha']
+        self.gamma = kwargs['gamma']
+        self.epsilon = kwargs['epsilon']
+        self.tau = kwargs['tau']
+        self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs.get('memory_capacity', 10**4)
-        self.batch_size = kwargs.get('batch_size', 32)
+        self.memory_capacity = kwargs['memory_capacity']
+        self.batch_size = kwargs['batch_size']
         self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
         self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')


### PR DESCRIPTION
## 概要

### 背景
- kwargs.getで参照していた引数を全て直接参照するようにして、変数がない場合はエラーを吐かせたい

## 動作検証
- [x] ちゃんと全アルゴリズム動いた
