### PR TITLE
保存ファイル名をデフォルトパラメータと異なるパラメータのみだったのを全パラメータ付けるよう変更

### DIFF
--- a/utils/make_param_file_utils.py
+++ b/utils/make_param_file_utils.py
@@ -81,8 +81,45 @@ def compare_base_make_folder(env_name, algo, ex_param):
     return results_dir
 
 
+def ex_param_make_folder(env_name, algo, ex_param):
+    if algo == 'DQN' or algo == 'DDQN' or algo == 'DuelingDQN' or algo == 'DuelingDDQN' or algo == 'DQN_RND':
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size']
+        ex_folder_path = f'log/{env_name}/{algo}/'
+        os.makedirs(ex_folder_path, exist_ok=True)
+        folder_name = algo
+        for k, v in ex_param.items():
+            if k in use_param:
+                folder_name += f'_{k}{v}'
+        results_dir = f'{ex_folder_path}{folder_name}/'
+        os.makedirs(results_dir, exist_ok=True)
+    elif algo == 'ConvDQN' or algo == 'ConvDDQN' or algo == 'ConvDQN_RND' or algo == 'ConvDQNAtari':
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size', 'neighbor_frames']
+        ex_folder_path = f'log/{env_name}/{algo}/'
+        os.makedirs(ex_folder_path, exist_ok=True)
+        folder_name = algo
+        for k, v in ex_param.items():
+            if k in use_param:
+                folder_name += f'_{k}{v}'
+        results_dir = f'{ex_folder_path}{folder_name}/'
+        os.makedirs(results_dir, exist_ok=True)
+    elif algo == 'RSRSDQN' or algo == 'RSRSDDQN' or algo == 'RSRSDuelingDQN' or algo == 'RSRSDuelingDDQN' or algo == 'RSRSAlephDQN' or algo == 'RSRSAlephQEpsDQN' or algo == 'RSRSAlephQEpsRASDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSDQN' or algo == 'ConvRSRSDynDQN' or algo == 'ConvRSRSAlephDQN' or algo == 'ConvRSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSAlephQEpsRASChoiceDQNAtari':
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size', 'neighbor_frames', 'warmup', 'k', 'zeta', 'aleph_G']
+        ex_folder_path = f'log/{env_name}/{algo}/'
+        os.makedirs(ex_folder_path, exist_ok=True)
+        folder_name = algo
+        for k, v in ex_param.items():
+            if k in use_param:
+                folder_name += f'_{k}{v}'
+        results_dir = f'{ex_folder_path}{folder_name}/'
+        os.makedirs(results_dir, exist_ok=True)
+    else:
+        print(f'Cannot make file for algorithm {algo}')
+        exit(1)
+    return results_dir
+
+
 def make_param_file(env_name, algo, param, model, policy, agent):
-    result_dir_path = compare_base_make_folder(env_name, algo, param)
+    result_dir_path = ex_param_make_folder(env_name, algo, param)
     f = open(result_dir_path + 'hyperparameter_list.txt', mode='w', encoding='utf-8')
     f.write(f'param: {param}\n')
     f.write(f'model: {model}\n')


### PR DESCRIPTION
## 概要

### 背景
- デフォルトパラメータがデフォルト感がないので、作成されるフォルダ名がよく分からん感じになってる
- 短くなることは嬉しいが、それより、全部見れた方が今は嬉しい

## 動作検証
- [x] 全パラメータが載ったフォルダ名が作成される
- [x] 全アルゴリズムで実験が回せる
