### PR TITLE
replay bufferとepisodic memoryのcapacityサイズのパラメータを分離

### DIFF
--- a/policy/conv_ddqn.py
+++ b/policy/conv_ddqn.py
@@ -21,9 +21,9 @@ class ConvDDQN(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_dqn.py
+++ b/policy/conv_dqn.py
@@ -21,9 +21,9 @@ class ConvDQN(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_dqn_atari.py
+++ b/policy/conv_dqn_atari.py
@@ -25,9 +25,9 @@ class ConvDQNAtari(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames).float()

--- a/policy/conv_dqn_rnd.py
+++ b/policy/conv_dqn_rnd.py
@@ -22,9 +22,9 @@ class ConvDQN_RND(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_rsrs_dqn.py
+++ b/policy/conv_rsrs_dqn.py
@@ -26,10 +26,11 @@ class ConvRSRSDQN(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_rsrsaleph_dqn.py
+++ b/policy/conv_rsrsaleph_dqn.py
@@ -26,10 +26,11 @@ class ConvRSRSAlephDQN(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
@@ -27,10 +27,11 @@ class ConvRSRSAlephQEpsRASChoiceDQNAtari:
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -27,10 +27,11 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/conv_rsrsdyn_dqn.py
+++ b/policy/conv_rsrsdyn_dqn.py
@@ -26,10 +26,11 @@ class ConvRSRSDynDQN(nn.Module):
         self.state_space = kwargs['state_space']
         self.frame_shape = kwargs['frame_shape']
         self.neighbor_frames = kwargs['neighbor_frames']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)

--- a/policy/ddqn.py
+++ b/policy/ddqn.py
@@ -18,9 +18,9 @@ class DDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/dqn.py
+++ b/policy/dqn.py
@@ -18,9 +18,9 @@ class DQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/dqn_rnd.py
+++ b/policy/dqn_rnd.py
@@ -19,9 +19,9 @@ class DQN_RND:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/duelingddqn.py
+++ b/policy/duelingddqn.py
@@ -18,9 +18,9 @@ class DuelingDDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/duelingdqn.py
+++ b/policy/duelingdqn.py
@@ -18,9 +18,9 @@ class DuelingDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrs_ddqn.py
+++ b/policy/rsrs_ddqn.py
@@ -23,10 +23,11 @@ class RSRSDDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrs_dqn.py
+++ b/policy/rsrs_dqn.py
@@ -23,10 +23,11 @@ class RSRSDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrs_duelingddqn.py
+++ b/policy/rsrs_duelingddqn.py
@@ -23,10 +23,11 @@ class RSRSDuelingDDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrs_duelingdqn.py
+++ b/policy/rsrs_duelingdqn.py
@@ -23,10 +23,11 @@ class RSRSDuelingDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrsaleph_dqn.py
+++ b/policy/rsrsaleph_dqn.py
@@ -23,10 +23,11 @@ class RSRSAlephDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrsaleph_q_eps_dqn.py
+++ b/policy/rsrsaleph_q_eps_dqn.py
@@ -23,10 +23,11 @@ class RSRSAlephQEpsDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn.py
@@ -23,10 +23,11 @@ class RSRSAlephQEpsRASChoiceDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -24,10 +24,11 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/policy/rsrsaleph_q_eps_ras_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_dqn.py
@@ -23,10 +23,11 @@ class RSRSAlephQEpsRASDQN:
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
         self.state_space = kwargs['state_space']
-        self.memory_capacity = kwargs['memory_capacity']
+        self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
+        self.episodic_memory_capacity = kwargs['episodic_memory_capacity']
         self.batch_size = kwargs['batch_size']
-        self.replay_buffer = ReplayBuffer(self.memory_capacity, self.batch_size)
-        self.episodic_memory = EpisodicMemory(self.memory_capacity, self.batch_size, self.action_space)
+        self.replay_buffer = ReplayBuffer(self.replay_buffer_capacity, self.batch_size)
+        self.episodic_memory = EpisodicMemory(self.episodic_memory_capacity, self.batch_size, self.action_space)
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.model_class = model
         self.model = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)

--- a/utils/make_param_file_utils.py
+++ b/utils/make_param_file_utils.py
@@ -13,7 +13,7 @@ def compare_base_make_folder(env_name, algo, ex_param):
             'epsilon': 0.01,
             'tau': 0.01,
             'hidden_size': 128,
-            'memory_capacity': 10**4,
+            'replay_buffer_capacity': 10**4,
             'batch_size': 32,
         }
         folder_name = algo
@@ -35,7 +35,7 @@ def compare_base_make_folder(env_name, algo, ex_param):
             'epsilon': 0.01,
             'tau': 0.01,
             'hidden_size': 128,
-            'memory_capacity': 10**4,
+            'replay_buffer_capacity': 10**4,
             'batch_size': 32,
             'neighbor_frames': 4,
         }
@@ -58,7 +58,8 @@ def compare_base_make_folder(env_name, algo, ex_param):
             'epsilon': 0.01,
             'tau': 0.01,
             'hidden_size': 128,
-            'memory_capacity': 10**4,
+            'replay_buffer_capacity': 10**4,
+            'episodic_memory_capacity': 10**4,
             'batch_size': 32,
             'neighbor_frames': 4,
             'warmup': 10,
@@ -83,7 +84,7 @@ def compare_base_make_folder(env_name, algo, ex_param):
 
 def ex_param_make_folder(env_name, algo, ex_param):
     if algo == 'DQN' or algo == 'DDQN' or algo == 'DuelingDQN' or algo == 'DuelingDDQN' or algo == 'DQN_RND':
-        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size']
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'replay_buffer_capacity', 'batch_size']
         ex_folder_path = f'log/{env_name}/{algo}/'
         os.makedirs(ex_folder_path, exist_ok=True)
         folder_name = algo
@@ -93,7 +94,7 @@ def ex_param_make_folder(env_name, algo, ex_param):
         results_dir = f'{ex_folder_path}{folder_name}/'
         os.makedirs(results_dir, exist_ok=True)
     elif algo == 'ConvDQN' or algo == 'ConvDDQN' or algo == 'ConvDQN_RND':
-        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size', 'neighbor_frames']
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'replay_buffer_capacity', 'batch_size', 'neighbor_frames']
         ex_folder_path = f'log/{env_name}/{algo}/'
         os.makedirs(ex_folder_path, exist_ok=True)
         folder_name = algo
@@ -103,7 +104,7 @@ def ex_param_make_folder(env_name, algo, ex_param):
         results_dir = f'{ex_folder_path}{folder_name}/'
         os.makedirs(results_dir, exist_ok=True)
     elif algo == 'ConvDQNAtari':
-        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'epsilon_start', 'epsilon_end', 'epsilon_decay', 'learning_rate', 'target_update_freq', 'tau', 'hidden_size', 'memory_capacity', 'batch_size', 'warmup']
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'epsilon_start', 'epsilon_end', 'epsilon_decay', 'learning_rate', 'target_update_freq', 'tau', 'hidden_size', 'replay_buffer_capacity', 'batch_size', 'warmup']
         ex_folder_path = f'log/{env_name}/{algo}/'
         os.makedirs(ex_folder_path, exist_ok=True)
         folder_name = algo
@@ -113,7 +114,7 @@ def ex_param_make_folder(env_name, algo, ex_param):
         results_dir = f'{ex_folder_path}{folder_name}/'
         os.makedirs(results_dir, exist_ok=True)
     elif algo == 'RSRSDQN' or algo == 'RSRSDDQN' or algo == 'RSRSDuelingDQN' or algo == 'RSRSDuelingDDQN' or algo == 'RSRSAlephDQN' or algo == 'RSRSAlephQEpsDQN' or algo == 'RSRSAlephQEpsRASDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSDQN' or algo == 'ConvRSRSDynDQN' or algo == 'ConvRSRSAlephDQN' or algo == 'ConvRSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSAlephQEpsRASChoiceDQNAtari':
-        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'memory_capacity', 'batch_size', 'neighbor_frames', 'warmup', 'k', 'zeta', 'aleph_G']
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'replay_buffer_capacity', 'episodic_memory_capacity', 'batch_size', 'neighbor_frames', 'warmup', 'k', 'zeta', 'aleph_G']
         ex_folder_path = f'log/{env_name}/{algo}/'
         os.makedirs(ex_folder_path, exist_ok=True)
         folder_name = algo


### PR DESCRIPTION
## 概要

### 背景
- 現状RS^2で使用しているepisodic memoryとreplay bufferのサイズが同じ値でしか管理できていないので、これを分離したい

## 動作検証
- [x] 全アルゴリズム動作した
