### PR TITLE
alphaとlearning_rateを分離

### DIFF
--- a/policy/conv_ddqn.py
+++ b/policy/conv_ddqn.py
@@ -12,7 +12,7 @@ torch.set_default_dtype(torch.float64)
 class ConvDDQN(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -30,7 +30,7 @@ class ConvDDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -39,7 +39,7 @@ class ConvDDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/conv_dqn.py
+++ b/policy/conv_dqn.py
@@ -12,7 +12,7 @@ torch.set_default_dtype(torch.float64)
 class ConvDQN(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -30,7 +30,7 @@ class ConvDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -39,7 +39,7 @@ class ConvDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/conv_dqn_atari.py
+++ b/policy/conv_dqn_atari.py
@@ -10,7 +10,7 @@ from network.conv_atari_qnet import ConvQAtariNet
 class ConvDQNAtari(nn.Module):
     def __init__(self, model=ConvQAtariNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.epsilon_start = kwargs['epsilon_start']

--- a/policy/conv_dqn_rnd.py
+++ b/policy/conv_dqn_rnd.py
@@ -13,7 +13,7 @@ torch.set_default_dtype(torch.float64)
 class ConvDQN_RND(nn.Module):
     def __init__(self, model=ConvQNet, **kwargs):
         super().__init__()
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -35,8 +35,8 @@ class ConvDQN_RND(nn.Module):
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = ConvRNDNet(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False
@@ -51,8 +51,8 @@ class ConvDQN_RND(nn.Module):
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = ConvRNDNet(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False
 

--- a/policy/conv_rsrs_dqn.py
+++ b/policy/conv_rsrs_dqn.py
@@ -17,7 +17,7 @@ class ConvRSRSDQN(nn.Module):
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -37,7 +37,7 @@ class ConvRSRSDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -56,7 +56,7 @@ class ConvRSRSDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.E_G = 0

--- a/policy/conv_rsrsaleph_dqn.py
+++ b/policy/conv_rsrsaleph_dqn.py
@@ -17,7 +17,7 @@ class ConvRSRSAlephDQN(nn.Module):
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -37,7 +37,7 @@ class ConvRSRSAlephDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
 
@@ -48,7 +48,7 @@ class ConvRSRSAlephDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
 
     def q_value(self, state):

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
@@ -18,7 +18,7 @@ class ConvRSRSAlephQEpsRASChoiceDQNAtari:
         self.warmup_steps = 1e3
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -18,7 +18,7 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -42,8 +42,8 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = ConvRNDNet(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         for param in self.rnd_model_target.parameters():
@@ -60,8 +60,8 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = ConvRNDNet(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False

--- a/policy/conv_rsrsdyn_dqn.py
+++ b/policy/conv_rsrsdyn_dqn.py
@@ -17,7 +17,7 @@ class ConvRSRSDynDQN(nn.Module):
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -37,7 +37,7 @@ class ConvRSRSDynDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -56,7 +56,7 @@ class ConvRSRSDynDQN(nn.Module):
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.frame_shape, hidden_size=self.hidden_size, output_size=self.action_space, neighbor_frames=self.neighbor_frames)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.E_G = 0

--- a/policy/ddqn.py
+++ b/policy/ddqn.py
@@ -11,7 +11,7 @@ torch.set_default_dtype(torch.float64)
 
 class DDQN:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -27,7 +27,7 @@ class DDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -36,7 +36,7 @@ class DDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/dqn.py
+++ b/policy/dqn.py
@@ -11,7 +11,7 @@ torch.set_default_dtype(torch.float64)
 
 class DQN:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -27,7 +27,7 @@ class DQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -36,7 +36,7 @@ class DQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/dqn_rnd.py
+++ b/policy/dqn_rnd.py
@@ -12,7 +12,7 @@ torch.set_default_dtype(torch.float64)
 
 class DQN_RND:
     def __init__(self, model=QNet, **kwargs):
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -32,8 +32,8 @@ class DQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = RNDNet(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.hidden_size)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False
@@ -48,8 +48,8 @@ class DQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = RNDNet(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.hidden_size)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False
 

--- a/policy/duelingddqn.py
+++ b/policy/duelingddqn.py
@@ -11,7 +11,7 @@ torch.set_default_dtype(torch.float64)
 
 class DuelingDDQN:
     def __init__(self, model=DuelingNet, **kwargs):
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -27,7 +27,7 @@ class DuelingDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -36,7 +36,7 @@ class DuelingDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/duelingdqn.py
+++ b/policy/duelingdqn.py
@@ -11,7 +11,7 @@ torch.set_default_dtype(torch.float64)
 
 class DuelingDQN:
     def __init__(self, model=DuelingNet, **kwargs):
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -27,7 +27,7 @@ class DuelingDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
 
     def reset(self):
@@ -36,7 +36,7 @@ class DuelingDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
 
     def q_value(self, state):
         s = torch.tensor(state, dtype=torch.float64).to(self.device).unsqueeze(0)

--- a/policy/rsrs_ddqn.py
+++ b/policy/rsrs_ddqn.py
@@ -16,7 +16,7 @@ class RSRSDDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -53,7 +53,7 @@ class RSRSDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.E_G = 0

--- a/policy/rsrs_dqn.py
+++ b/policy/rsrs_dqn.py
@@ -16,7 +16,7 @@ class RSRSDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -53,7 +53,7 @@ class RSRSDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.E_G = 0

--- a/policy/rsrs_duelingddqn.py
+++ b/policy/rsrs_duelingddqn.py
@@ -16,7 +16,7 @@ class RSRSDuelingDDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSDuelingDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -53,7 +53,7 @@ class RSRSDuelingDDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
         self.E_G = 0

--- a/policy/rsrs_duelingdqn.py
+++ b/policy/rsrs_duelingdqn.py
@@ -16,7 +16,7 @@ class RSRSDuelingDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSDuelingDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         self.total_step = 0
@@ -50,7 +50,7 @@ class RSRSDuelingDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         self.total_step = 0
 

--- a/policy/rsrsaleph_dqn.py
+++ b/policy/rsrsaleph_dqn.py
@@ -16,7 +16,7 @@ class RSRSAlephDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSAlephDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
 
@@ -45,7 +45,7 @@ class RSRSAlephDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
 
     def q_value(self, state):

--- a/policy/rsrsaleph_q_eps_dqn.py
+++ b/policy/rsrsaleph_q_eps_dqn.py
@@ -16,7 +16,7 @@ class RSRSAlephQEpsDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSAlephQEpsDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
 
@@ -45,7 +45,7 @@ class RSRSAlephQEpsDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
 
     def q_value(self, state):

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn.py
@@ -16,7 +16,7 @@ class RSRSAlephQEpsRASChoiceDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSAlephQEpsRASChoiceDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
 
@@ -45,7 +45,7 @@ class RSRSAlephQEpsRASChoiceDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
 
     def q_value(self, state):

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -17,7 +17,7 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -39,8 +39,8 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = RNDNet(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.hidden_size)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
         for param in self.rnd_model_target.parameters():
@@ -57,8 +57,8 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         self.rnd_model_pred.to(self.device)
         self.rnd_model_target = RNDNet(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.hidden_size)
         self.rnd_model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
-        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
+        self.rnd_optimizer = optim.Adam(self.rnd_model_pred.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
         for param in self.rnd_model_target.parameters():
             param.requires_grad = False

--- a/policy/rsrsaleph_q_eps_ras_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_dqn.py
@@ -16,7 +16,7 @@ class RSRSAlephQEpsRASDQN:
         self.warmup = kwargs['warmup']
         self.k = kwargs['k']
         self.zeta = kwargs['zeta']
-        self.alpha = kwargs['alpha']
+        self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
         self.epsilon = kwargs['epsilon']
         self.tau = kwargs['tau']
@@ -34,7 +34,7 @@ class RSRSAlephQEpsRASDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.criterion = nn.MSELoss(reduction='sum')
         self.n = np.zeros(self.action_space)
 
@@ -45,7 +45,7 @@ class RSRSAlephQEpsRASDQN:
         self.model.to(self.device)
         self.model_target = self.model_class(input_size=self.state_space, hidden_size=self.hidden_size, output_size=self.action_space)
         self.model_target.to(self.device)
-        self.optimizer = optim.Adam(self.model.parameters(), lr=self.alpha)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
         self.n = np.zeros(self.action_space)
 
     def q_value(self, state):


### PR DESCRIPTION
## 概要

### 背景
- atari用のDQNでRMSpropを使用しているため、lrとalphaを分離したかった

### 解決方針
- 他方策ではAdamを使用しているため、表記に合わせてlrを使用、alphaは現状RMSpropのみで使用

## 動作検証

- [x] 動いた
