### PR TITLE
epsilon-greedyと微少数epsilonを分離(微少数epsilon-dash)

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ if __name__ == '__main__':
     batch_size = 32
     neighbor_frames = 4
     k = 5
+    epsilon_dash = 0.001
     zeta = 0.01
     aleph_G = 0
     for algo in algos:
@@ -133,6 +134,7 @@ if __name__ == '__main__':
             'batch_size': batch_size,
             'neighbor_frames': neighbor_frames,
             'warmup': warmup,
+            'epsilon_dash': epsilon_dash,
             'k': k,
             'zeta': zeta,
             'aleph_G': aleph_G,

--- a/policy/conv_rsrs_dqn.py
+++ b/policy/conv_rsrs_dqn.py
@@ -19,7 +19,7 @@ class ConvRSRSDQN(nn.Module):
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -158,7 +158,7 @@ class ConvRSRSDQN(nn.Module):
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/conv_rsrsaleph_dqn.py
+++ b/policy/conv_rsrsaleph_dqn.py
@@ -19,7 +19,7 @@ class ConvRSRSAlephDQN(nn.Module):
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -144,7 +144,7 @@ class ConvRSRSAlephDQN(nn.Module):
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_atari.py
@@ -20,7 +20,7 @@ class ConvRSRSAlephQEpsRASChoiceDQNAtari:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -124,7 +124,7 @@ class ConvRSRSAlephQEpsRASChoiceDQNAtari:
         regularization_squared_distance = squared_distance / average_squared_distance
         regularization_squared_distance = np.maximum(regularization_squared_distance, 0)
 
-        inverse_kernel_function = self.epsilon / (regularization_squared_distance + self.epsilon)
+        inverse_kernel_function = self.epsilon_dash / (regularization_squared_distance + self.epsilon_dash)
         sum_kernel = np.sum(inverse_kernel_function)
         weight = inverse_kernel_function / sum_kernel
         self.n = np.average(action_vec[I.flatten()], weights=weight, axis=0)

--- a/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/conv_rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -20,7 +20,7 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -147,7 +147,7 @@ class ConvRSRSAlephQEpsRASChoiceDQN_RND:
         regularization_squared_distance = squared_distance / average_squared_distance
         regularization_squared_distance = np.maximum(regularization_squared_distance, 0)
 
-        inverse_kernel_function = self.epsilon / (regularization_squared_distance + self.epsilon)
+        inverse_kernel_function = self.epsilon_dash / (regularization_squared_distance + self.epsilon_dash)
         sum_kernel = np.sum(inverse_kernel_function)
         weight = inverse_kernel_function / sum_kernel
         self.n = np.average(action_vec[I.flatten()], weights=weight, axis=0)

--- a/policy/conv_rsrsdyn_dqn.py
+++ b/policy/conv_rsrsdyn_dqn.py
@@ -19,7 +19,7 @@ class ConvRSRSDynDQN(nn.Module):
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -153,7 +153,7 @@ class ConvRSRSDynDQN(nn.Module):
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrs_ddqn.py
+++ b/policy/rsrs_ddqn.py
@@ -18,7 +18,7 @@ class RSRSDDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -156,7 +156,7 @@ class RSRSDDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrs_dqn.py
+++ b/policy/rsrs_dqn.py
@@ -18,7 +18,7 @@ class RSRSDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -154,7 +154,7 @@ class RSRSDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrs_duelingddqn.py
+++ b/policy/rsrs_duelingddqn.py
@@ -18,7 +18,7 @@ class RSRSDuelingDDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -156,7 +156,7 @@ class RSRSDuelingDDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrs_duelingdqn.py
+++ b/policy/rsrs_duelingdqn.py
@@ -18,7 +18,7 @@ class RSRSDuelingDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -140,7 +140,7 @@ class RSRSDuelingDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrsaleph_dqn.py
+++ b/policy/rsrsaleph_dqn.py
@@ -18,7 +18,7 @@ class RSRSAlephDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -148,7 +148,7 @@ class RSRSAlephDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrsaleph_q_eps_dqn.py
+++ b/policy/rsrsaleph_q_eps_dqn.py
@@ -18,7 +18,7 @@ class RSRSAlephQEpsDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -129,7 +129,7 @@ class RSRSAlephQEpsDQN:
         regularization_squared_distance = np.divide(squared_distance, average_squared_distance, out=np.zeros_like(squared_distance), where=average_squared_distance!=0)
         regularization_squared_distance -= self.zeta
         np.putmask(regularization_squared_distance, regularization_squared_distance < 0, 0)
-        inverse_kernel_function = [self.epsilon / (i + self.epsilon) for i in regularization_squared_distance]
+        inverse_kernel_function = [self.epsilon_dash / (i + self.epsilon_dash) for i in regularization_squared_distance]
         sum_kernel = np.sum(inverse_kernel_function)
         weight = [k_i/sum_kernel for k_i in inverse_kernel_function]
         self.n = np.average(action_vec, weights=weight, axis=0)

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn.py
@@ -18,7 +18,7 @@ class RSRSAlephQEpsRASChoiceDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -118,7 +118,7 @@ class RSRSAlephQEpsRASChoiceDQN:
         regularization_squared_distance = squared_distance / average_squared_distance
         regularization_squared_distance = np.maximum(regularization_squared_distance, 0)
 
-        inverse_kernel_function = self.epsilon / (regularization_squared_distance + self.epsilon)
+        inverse_kernel_function = self.epsilon_dash / (regularization_squared_distance + self.epsilon_dash)
         sum_kernel = np.sum(inverse_kernel_function)
         weight = inverse_kernel_function / sum_kernel
         self.n = np.average(action_vec[I.flatten()], weights=weight, axis=0)

--- a/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_dqn_rnd.py
@@ -19,7 +19,7 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -144,7 +144,7 @@ class RSRSAlephQEpsRASChoiceDQN_RND:
         regularization_squared_distance = squared_distance / average_squared_distance
         regularization_squared_distance = np.maximum(regularization_squared_distance, 0)
 
-        inverse_kernel_function = self.epsilon / (regularization_squared_distance + self.epsilon)
+        inverse_kernel_function = self.epsilon_dash / (regularization_squared_distance + self.epsilon_dash)
         sum_kernel = np.sum(inverse_kernel_function)
         weight = inverse_kernel_function / sum_kernel
         self.n = np.average(action_vec[I.flatten()], weights=weight, axis=0)

--- a/policy/rsrsaleph_q_eps_ras_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_dqn.py
@@ -18,7 +18,7 @@ class RSRSAlephQEpsRASDQN:
         self.zeta = kwargs['zeta']
         self.learning_rate = kwargs['learning_rate']
         self.gamma = kwargs['gamma']
-        self.epsilon = kwargs['epsilon']
+        self.epsilon_dash = kwargs['epsilon_dash']
         self.tau = kwargs['tau']
         self.hidden_size = kwargs['hidden_size']
         self.action_space = kwargs['action_space']
@@ -126,7 +126,7 @@ class RSRSAlephQEpsRASDQN:
         regularization_squared_distance = squared_distance / average_squared_distance
         regularization_squared_distance = np.maximum(regularization_squared_distance, 0)
 
-        inverse_kernel_function = self.epsilon / (regularization_squared_distance + self.epsilon)
+        inverse_kernel_function = self.epsilon_dash / (regularization_squared_distance + self.epsilon_dash)
         sum_kernel = np.sum(inverse_kernel_function)
         weight = inverse_kernel_function / sum_kernel
         self.n = np.average(action_vec[I.flatten()], weights=weight, axis=0)

--- a/utils/make_param_file_utils.py
+++ b/utils/make_param_file_utils.py
@@ -55,7 +55,7 @@ def compare_base_make_folder(env_name, algo, ex_param):
             'epi': 1000,
             'alpha': 0.001,
             'gamma': 0.99,
-            'epsilon': 0.01,
+            'epsilon_dash': 0.01,
             'tau': 0.01,
             'hidden_size': 128,
             'replay_buffer_capacity': 10**4,
@@ -114,7 +114,7 @@ def ex_param_make_folder(env_name, algo, ex_param):
         results_dir = f'{ex_folder_path}{folder_name}/'
         os.makedirs(results_dir, exist_ok=True)
     elif algo == 'RSRSDQN' or algo == 'RSRSDDQN' or algo == 'RSRSDuelingDQN' or algo == 'RSRSDuelingDDQN' or algo == 'RSRSAlephDQN' or algo == 'RSRSAlephQEpsDQN' or algo == 'RSRSAlephQEpsRASDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN' or algo == 'RSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSDQN' or algo == 'ConvRSRSDynDQN' or algo == 'ConvRSRSAlephDQN' or algo == 'ConvRSRSAlephQEpsRASChoiceDQN_RND' or algo == 'ConvRSRSAlephQEpsRASChoiceDQNAtari':
-        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon', 'tau', 'hidden_size', 'replay_buffer_capacity', 'episodic_memory_capacity', 'batch_size', 'neighbor_frames', 'warmup', 'k', 'zeta', 'aleph_G']
+        use_param = ['sim', 'epi', 'alpha', 'gamma', 'epsilon_dash', 'tau', 'hidden_size', 'replay_buffer_capacity', 'episodic_memory_capacity', 'batch_size', 'neighbor_frames', 'warmup', 'k', 'zeta', 'aleph_G']
         ex_folder_path = f'log/{env_name}/{algo}/'
         os.makedirs(ex_folder_path, exist_ok=True)
         folder_name = algo


### PR DESCRIPTION
## 概要

### 背景
- epsilon-greedyとRS^2の微少数epsilonが現状同じ変数として管理されていたため、これを分離

### 解決方針
- RS^2の微少数epsilonをepsilon_dashとして定義

## 動作検証
- [x] RS^2-DQNで動いた、他のは確認してない
