### PR TITLE
centroids計算用の減衰率を追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,7 @@ if __name__ == '__main__':
     zeta = 0.01
     global_aleph = 500
     global_value_size = 500
+    centroids_decay = 0.9
 
     # optimizer parameters
     adam_learning_rate = 0.001
@@ -160,6 +161,7 @@ if __name__ == '__main__':
             'zeta': zeta,
             'global_aleph': global_aleph,
             'global_value_size': global_value_size,
+            'centroids_decay': centroids_decay,
             'adam_learning_rate': adam_learning_rate,
             'rmsprop_learning_rate': rmsprop_learning_rate,
             'rmsprop_alpha': rmsprop_alpha,

--- a/policy/rsrsaleph_q_eps_ras_choice_centroid_alephg_dqn.py
+++ b/policy/rsrsaleph_q_eps_ras_choice_centroid_alephg_dqn.py
@@ -21,6 +21,7 @@ class RSRSAlephQEpsRASChoiceCentroidAlephGDQN:
         self.aleph_beta = 1
         self.aleph_state = self.global_aleph
         self.global_value = 0
+        self.centroids_decay = kwargs['centroids_decay']
         self.adam_learning_rate = kwargs['adam_learning_rate']
         self.mseloss_reduction = kwargs['mseloss_reduction']
         self.replay_buffer_capacity = kwargs['replay_buffer_capacity']
@@ -155,8 +156,8 @@ class RSRSAlephQEpsRASChoiceCentroidAlephGDQN:
         self.aleph_state = self.aleph_beta * self.global_aleph + (1-self.aleph_beta) * max(q_values)
 
     def calculate_reliability(self, controllable_state, action):
-        self.pseudo_counts *= self.gamma
-        self.weights *= self.gamma
+        self.pseudo_counts *= self.centroids_decay
+        self.weights *= self.centroids_decay
 
         controllable_state_norm = controllable_state / (np.linalg.norm(controllable_state) + self.epsilon_dash)
 

--- a/utils/make_param_file_utils.py
+++ b/utils/make_param_file_utils.py
@@ -79,6 +79,7 @@ def compare_base_make_folder(env_name, algo, ex_param):
             'k': 5,
             'global_aleph': 500,
             'global_value_size': 500,
+            'centroids_decay': 0.9,
             'adam_learning_rate': 0.001,
             'rmsprop_learning_rate': 0.00025,
             'rmsprop_alpha': 0.95,


### PR DESCRIPTION
## 概要

### 背景
- centroid計算時の減衰率とQ値計算用gammaが同じ変数だったので分けた

## 動作検証
- [x] きちんと反映されてた
